### PR TITLE
Fix bug in Ruby Mersenne Twister example

### DIFF
--- a/ruby-mersenne-twister.rb
+++ b/ruby-mersenne-twister.rb
@@ -81,7 +81,7 @@ class MersenneTwister
   
   def generate_numbers
     for i in 0..623
-      y = @mt[i][31] + @mt[(i+1) % 624].last_bits(31)
+      y = (@mt[i][31] << 31) + @mt[(i+1) % 624].last_bits(31)
       @mt[i] = @mt[(i + 397) % 624] ^ (y >> 1)
       @mt[i] = @mt[i] ^ 2567483615 if y.odd?
     end


### PR DESCRIPTION
In Wikipedia's article on the MT19937 Mersenne Twister algorithm, the sample C code includes this line:

```c
uint32_t x = (state_array[k] & UMASK) | (state_array[j] & LMASK);
```

Where UMASK is defined as `(0xffffffffUL << 31)`, or in other words, 0x80000000. If the high bit in `state_array[k]` is set, the left part of the expression will therefore evaluate to 0x80000000.

The corresponding line in the sample Ruby code is:

```ruby
y = @mt[i][31] + @mt[(i+1) % 624].last_bits(31)
```

The problem with this is that if the high bit is set, `@mt[i][31]` will evaluate to 1 rather than 0x80000000.

The inventors of the algorithm provide C code at this web address:

http://www.math.sci.hiroshima-u.ac.jp/m-mat/MT/MT2002/CODES/mt19937ar.c

...and their implementation also adds in 0x80000000 (and not 1) if the high bit is set.